### PR TITLE
Switch to repository owner for concurrency

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -272,7 +272,7 @@ jobs:
       # Change this to self-hosted after setting up devspace as github actions runner
     runs-on: ubuntu-latest
     concurrency:
-      group: ${{ github.actor }}
+      group: ${{ github.repository_owner }}
     steps:
       # Accept Project Variables
     - name: Set Repo Project

--- a/.github/workflows/selfhosted.yml
+++ b/.github/workflows/selfhosted.yml
@@ -308,7 +308,7 @@ jobs:
     needs: test
     runs-on: self-hosted
     concurrency:
-      group: ${{ github.actor }}
+      group: ${{ github.repository_owner }}
     steps:
       # Accept Project Variables
     - name: Set Repo Project


### PR DESCRIPTION
This allows us to stop dual queuing on shared repos, in case multiple people want to queue builds 